### PR TITLE
Always clear placeholder class when element gains focus

### DIFF
--- a/jquery.html5support.js
+++ b/jquery.html5support.js
@@ -38,8 +38,10 @@ var HTML5Support = (function($){
             self.val(value).addClass(placeholder_klass);
         },
         clear_value = function() {
-            if (self.val() == value)
-            self.val('').removeClass(placeholder_klass);
+            if (self.val() == value) {
+                self.val('');
+            }
+            self.removeClass(placeholder_klass);
         };
         self.focus(clear_value).blur(set_value).blur();
     }


### PR DESCRIPTION
Fixes #7

Currently the placeholder class is only cleared when an input element gains focus AND its value is the placeholder text.

This is an issue if the value of the field is already set before being bound by placeholder.
